### PR TITLE
fix: registering subcommands outside of subcmd groups

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -176,7 +176,7 @@ export default class CommandLoader {
 							`Subcommand ${name} is missing a 'run' function.`,
 						);
 
-					subcommands[name] = subCmd;
+					subcommands[subCmd.name] = subCmd;
 					options.push(subCmd);
 				}
 			}
@@ -316,8 +316,7 @@ function getSubcommand(
 	if (subcmd in subcommands) return subcommands[subcmd];
 	else
 		throw new Error(
-			`Received unknown subcommand: '/${commandGroup.name} ${
-				group || ""
+			`Received unknown subcommand: '/${commandGroup.name} ${group || ""
 			} ${subcmd}'`,
 		);
 }


### PR DESCRIPTION
Currently, subcommands outside of a subcommand group are registered in the command group with the file extension.
This PR fixes it, so subcommands can be used.