### PR TITLE
refactor: get rid of toFileURL

### DIFF
--- a/src/commands/guild.ts
+++ b/src/commands/guild.ts
@@ -6,7 +6,6 @@ import type { GuildCommand, Middleware } from "../types.js";
 import { readdirSync } from "node:fs";
 
 import checkCommand, { LoadError } from "./check.function.js";
-import { toFileURL } from "./index.js";
 import { importCommand } from "../util.js";
 
 const guildCommands: { [name: string]: GuildCommand } = {};
@@ -50,7 +49,7 @@ export async function init(
 		const command: GuildCommand = {
 			type: ChatInput,
 			shouldCreateFor: defaultShouldCreateFor,
-			...(await importCommand(toFileURL(`${folder}/${fileName}`))),
+			...(await importCommand(`${folder}/${fileName}`)),
 			name,
 			apiCommands: new Map(),
 		};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -21,12 +21,7 @@ import type {
 import { readdirSync, existsSync } from "node:fs";
 
 import checkCommand, { LoadError } from "./check.function.js";
-import { pathToFileURL } from "node:url";
 import { importCommand } from "../util.js";
-
-export function toFileURL(path: string) {
-	return pathToFileURL(path).href;
-}
 
 const READONLY = { writable: false, configurable: false, enumerable: true };
 
@@ -118,11 +113,10 @@ export default class CommandLoader {
 				);
 		}
 
-		const file = toFileURL(`${this.root}/${subfolder}/${name}.js`);
 		let command: Command = {
 			type: ChatInput,
 			dmPermission: this.defaultDmPermission,
-			...(await importCommand(file)),
+			...(await importCommand(`${this.root}/${subfolder}/${name}.js`)),
 			name,
 			subfolder,
 		};
@@ -143,7 +137,7 @@ export default class CommandLoader {
 		const subcommandGroups: { [name: string]: SubcommandGroup } = {};
 		const cmd: CommandGroup = {
 			...(existsSync(`${path}/$info.js`)
-				? await importCommand(toFileURL(`${path}/$info.js`))
+				? await importCommand(`${path}/$info.js`)
 				: { description: `/${cmdName}` }),
 			name: cmdName,
 			type: ChatInput,
@@ -168,7 +162,7 @@ export default class CommandLoader {
 				);
 				if (ext) {
 					const subCmd: Subcommand = {
-						...(await importCommand(toFileURL(`${path}/${name}`))),
+						...(await importCommand(`${path}/${name}`)),
 						name: name.slice(0, -(ext.length + 1)),
 						type: Subcommand,
 					};
@@ -204,7 +198,7 @@ export default class CommandLoader {
 		);
 		const group: SubcommandGroup = {
 			...(ext
-				? await importCommand(toFileURL(`${path}/$info.${ext}`))
+				? await importCommand(`${path}/$info.${ext}`)
 				: { description: `/${parent} ${groupName}` }),
 			name: groupName,
 			type: SubcommandGroup,
@@ -240,7 +234,7 @@ export default class CommandLoader {
 
 	async createSubCommand(directory: string, name: string): Promise<Subcommand> {
 		const subcommandData: Omit<Subcommand, "autocompleteHandler"> =
-			await importCommand(toFileURL(`${directory}/${name}`));
+			await importCommand(`${directory}/${name}`);
 		const { autocomplete } = subcommandData;
 		name = name.slice(
 			0,

--- a/src/commands/owner.ts
+++ b/src/commands/owner.ts
@@ -3,7 +3,6 @@ const { Subcommand, SubcommandGroup } = ApplicationCommandOptionType;
 import checkCommand, { NAME_REGEX, LoadError } from "./check.function.js";
 import type { ChatInputCommand, ChatInputHandler } from "../types.js";
 import { readdirSync } from "node:fs";
-import { toFileURL } from "./index.js";
 import { importCommand } from "../util.js";
 
 export const command: Partial<ChatInputCommand> = {};
@@ -57,7 +56,7 @@ export async function load(
 			),
 		),
 	)) {
-		const command = await importCommand(toFileURL(`${folder}/${cmd}`));
+		const command = await importCommand(`${folder}/${cmd}`);
 		if (!("type" in command)) command.type = Subcommand;
 		else if (command.type !== Subcommand && command.type !== SubcommandGroup)
 			throw new LoadError(

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,6 @@
+import { pathToFileURL } from "node:url";
+
 export async function importCommand(path: string) {
-	const command = await import(path);
+	const command = await import(pathToFileURL(path).href);
 	return command.default || command; // potentially switch to nullish coalescing
 }


### PR DESCRIPTION
Puts the conversion from path to file URL in importCommand instead of having a (useless) separate util functoin