### PR TITLE
fix: autocomplete for subcommands

### DIFF
--- a/src/commands/check.function.ts
+++ b/src/commands/check.function.ts
@@ -70,7 +70,7 @@ export default function checkCommand(
 function checkOptions(
 	cmdName: string,
 	options: ChatInputCommand["options"],
-	autocompleteHandler?: AutocompleteHandler,
+	autocomplete?: AutocompleteHandler,
 ) {
 	if (!Array.isArray(options))
 		throw new LoadError(cmdName, "'options' must be an Array.");
@@ -114,7 +114,7 @@ function checkOptions(
 				);
 			if (
 				subCommands.some(
-					({ type }: { type: ApplicationCommandOptionType }) =>
+					({ type }: { type: ApplicationCommandOptionType; }) =>
 						type !== Subcommand,
 				)
 			)
@@ -125,12 +125,12 @@ function checkOptions(
 			subCommands.forEach(checkCommand);
 		} else if (type === Subcommand) checkCommand(option);
 		else if (option.autocomplete) {
-			if (!autocompleteHandler)
+			if (!autocomplete)
 				throw new LoadError(
 					cmdName,
 					"Command has an autocomplete option, but no autocomplete handler.",
 				);
-			if (typeof autocompleteHandler !== "function")
+			if (typeof autocomplete !== "function")
 				throw new LoadError(
 					cmdName,
 					"Autocomplete handler must be a function.",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -139,8 +139,8 @@ export default class CommandLoader {
 	async createCommandGroup(cmdName: string) {
 		const path = `${this.root}/${cmdName}`;
 		const options: (Subcommand | SubcommandGroup)[] = [];
-		const subcommands: { [name: string]: Subcommand } = {};
-		const subcommandGroups: { [name: string]: SubcommandGroup } = {};
+		const subcommands: { [name: string]: Subcommand; } = {};
+		const subcommandGroups: { [name: string]: SubcommandGroup; } = {};
 		const cmd: CommandGroup = {
 			...(existsSync(`${path}/$info.js`)
 				? await importCommand(toFileURL(`${path}/$info.js`))
@@ -198,7 +198,7 @@ export default class CommandLoader {
 			);
 
 		const options: Subcommand[] = [];
-		const subcommands: { [name: string]: Subcommand } = {};
+		const subcommands: { [name: string]: Subcommand; } = {};
 		const ext: string | undefined = this.commandFileExtension.find((ext) =>
 			existsSync(`${path}/$info.${ext}`),
 		);
@@ -252,21 +252,12 @@ export default class CommandLoader {
 				).length + 1
 			),
 		);
-		if (!autocomplete)
-			return {
-				...subcommandData,
-				name,
-				type: Subcommand,
-			};
-
-		if (typeof autocomplete !== "function")
+		if (autocomplete && typeof autocomplete !== "function")
 			throw new LoadError(name, "Subcommand autocomplete must be a function.");
 		return {
 			...subcommandData,
 			name,
 			type: Subcommand,
-			autocompleteHandler: autocomplete,
-			autocomplete: !!autocomplete,
 		};
 	}
 }
@@ -291,7 +282,7 @@ function getSubcommand(
 ) {
 	const group = options.getSubcommandGroup();
 	const subcmd = options.getSubcommand();
-	let subcommands: { [name: string]: Subcommand };
+	let subcommands: { [name: string]: Subcommand; };
 	if (group) {
 		if (group in commandGroup.subcommandGroups)
 			subcommands = commandGroup.subcommandGroups[group].subcommands;


### PR DESCRIPTION
Having an autocomplete option in a subcommand part of a subcommand group caused an exception saying "autocomplete handler must be a function".
This commit fixes it.