### PR TITLE
Subcommand autocomplete check

### DIFF
--- a/src/commands/check.function.ts
+++ b/src/commands/check.function.ts
@@ -123,7 +123,8 @@ function checkOptions(
 					"Subcommand group options can only be subcommands.",
 				);
 			subCommands.forEach(checkCommand);
-		} else if (type === Subcommand) checkCommand(option);
+		}
+		else if (type === Subcommand) checkCommand(option);
 		else if (option.autocomplete) {
 			if (!autocomplete)
 				throw new LoadError(

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -233,8 +233,7 @@ export default class CommandLoader {
 	}
 
 	async createSubCommand(directory: string, name: string): Promise<Subcommand> {
-		const subcommandData: Omit<Subcommand, "autocompleteHandler"> =
-			await importCommand(`${directory}/${name}`);
+		const subcommandData = await importCommand(`${directory}/${name}`);
 		const { autocomplete } = subcommandData;
 		name = name.slice(
 			0,
@@ -267,7 +266,7 @@ function commandGroupAutocomplete(
 	this: CommandGroup,
 	interaction: AutocompleteInteraction,
 ) {
-	getSubcommand(this, interaction).autocompleteHandler?.(interaction);
+	getSubcommand(this, interaction).autocomplete?.(interaction);
 }
 
 function getSubcommand(

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -266,7 +266,9 @@ function commandGroupAutocomplete(
 	this: CommandGroup,
 	interaction: AutocompleteInteraction,
 ) {
-	getSubcommand(this, interaction).autocomplete?.(interaction);
+	const { autocomplete, name } = getSubcommand(this, interaction);
+	if (autocomplete) autocomplete(interaction);
+	else console.warn(`Got autocomplete for subcommand ${name} which doesn't have an autocomplete handler.`);
 }
 
 function getSubcommand(

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,8 +27,7 @@ export interface SubcommandGroup extends ApplicationCommandSubGroupData {
 export interface Subcommand
 	extends Omit<ApplicationCommandSubCommandData, "autocomplete"> {
 	run: ChatInputHandler;
-	autocomplete?: boolean | AutocompleteHandler;
-	autocompleteHandler?: AutocompleteHandler;
+	autocomplete?: AutocompleteHandler;
 }
 export interface CommandGroup extends ChatInputCommand {
 	subcommandGroups: { [name: string]: SubcommandGroup };


### PR DESCRIPTION
This PR adds a check for subcommand autocomplete interactions, emitting a warning if the target subcommand doesn't have an autocomplete handler.